### PR TITLE
Removed preset of req.cookies which conflicted with cookie-parse package

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,12 @@ function createRes(callback) {
     headers[x.toLowerCase()] = y;
     return res;
   };
-  res.getHeader = (x) => headers[x];
+  res.getHeader = function(name) {
+    if ( 'undefined' !== typeof headers[name] ) {
+      return headers[name];
+    }
+    return null; 
+  };
   // res.get=(x) => {
   // 	return headers[x]
   // }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ function createReq(path, options) {
     {
       method: "GET",
       host: "",
-      cookies: {},
       query: {},
       url: path,
       headers: {},


### PR DESCRIPTION
Express does not populate req.cookies by default. This break the popular "cookie-parse" middleware package as it sees the empty object and does not parse cookies. Removing this empty object default fixes the problem.